### PR TITLE
Feat/keycloak logout support

### DIFF
--- a/openidconnect/lib/openidconnect.dart
+++ b/openidconnect/lib/openidconnect.dart
@@ -29,6 +29,7 @@ part 'src/models/requests/interactive_authorization_request.dart';
 part 'src/models/requests/password_authorization_request.dart';
 part 'src/models/requests/refresh_request.dart';
 part 'src/models/requests/logout_request.dart';
+part 'src/models/requests/logout_token_request.dart';
 part 'src/models/requests/revoke_token_request.dart';
 part 'src/models/requests/device_authorization_request.dart';
 part 'src/models/requests/user_info_request.dart';
@@ -269,6 +270,21 @@ class OpenIdConnect {
     try {
       await httpRetry(
         () => http.get(url),
+      );
+    } on HttpResponseException catch (e) {
+      throw LogoutException(e.toString());
+    }
+  }
+
+  /// Keycloak compatible logout
+  /// see https://www.keycloak.org/docs/latest/securing_apps/#logout-endpoint
+  static Future<void> logoutToken({required LogoutTokenRequest request}) async {
+    if (request.configuration.endSessionEndpoint == null) return;
+
+    final url = Uri.parse(request.configuration.endSessionEndpoint!);
+    try {
+      await httpRetry(
+            () => http.post(url, body: request.toMap()),
       );
     } on HttpResponseException catch (e) {
       throw LogoutException(e.toString());

--- a/openidconnect/lib/src/models/requests/logout_token_request.dart
+++ b/openidconnect/lib/src/models/requests/logout_token_request.dart
@@ -1,0 +1,25 @@
+part of openidconnect;
+
+class LogoutTokenRequest {
+  final String refreshToken;
+  final String? clientId;
+  final String? clientSecret;
+  final String? redirectUrl;
+  final OpenIdConfiguration configuration;
+
+  const LogoutTokenRequest({
+    required this.configuration,
+    required this.refreshToken,
+    this.clientId,
+    this.clientSecret,
+    this.redirectUrl,
+  });
+
+  Map<String, String> toMap() {
+    var map = {"refresh_token": refreshToken};
+    if (clientId != null) map = {"client_id": clientId!, ...map};
+    if (clientSecret != null) map = {"client_secret": clientSecret!, ...map};
+    if (redirectUrl != null) map = {"redirect_uri": redirectUrl!, ...map};
+    return map;
+  }
+}

--- a/openidconnect/lib/src/models/requests/revoke_token_request.dart
+++ b/openidconnect/lib/src/models/requests/revoke_token_request.dart
@@ -6,17 +6,25 @@ class RevokeTokenRequest {
   final OpenIdConfiguration configuration;
   final String token;
   final TokenType tokenType;
+  final String? clientId;
+  final String? clientSecret;
 
   const RevokeTokenRequest({
     required this.configuration,
     required this.token,
     required this.tokenType,
+    this.clientId,
+    this.clientSecret,
   });
 
-  Map<String, String> toMap() => {
-        "token": token,
-        "token_type_hint": tokenType == TokenType.accessToken
-            ? "access_token"
-            : "refresh_token",
-      };
+  Map<String, String> toMap() {
+    var map = {"token": token,
+      "token_type_hint": tokenType == TokenType.accessToken
+          ? "access_token"
+          : "refresh_token",
+    };
+    if (clientId != null) map = {"client_id": clientId!, ...map};
+    if (clientSecret != null) map = {"client_secret": clientSecret!, ...map};
+    return map;
+  }
 }

--- a/openidconnect/lib/src/openidconnect_client.dart
+++ b/openidconnect/lib/src/openidconnect_client.dart
@@ -271,6 +271,29 @@ class OpenIdConnectClient {
     _raiseEvent(AuthEvent(AuthEventTypes.NotLoggedIn));
   }
 
+  Future<void> revokeToken() async {
+    if (_autoRenewTimer != null) _autoRenewTimer = null;
+
+    if (_identity == null) return;
+
+    try {
+      //Make sure we have the discovery information
+      await _verifyDiscoveryDocument();
+
+      await OpenIdConnect.revokeToken(
+        request: RevokeTokenRequest(
+          clientId: clientId,
+          clientSecret: clientSecret,
+          configuration: configuration!,
+          token: _identity!.accessToken,
+          tokenType: TokenType.accessToken,
+        ),
+      );
+    } on Exception catch (e) {
+      _raiseEvent(AuthEvent(AuthEventTypes.Error, message: e.toString()));
+    }
+  }
+
   /// Keycloak compatible logout
   /// see https://www.keycloak.org/docs/latest/securing_apps/#logout-endpoint
   Future<void> logoutToken() async {

--- a/openidconnect/lib/src/openidconnect_client.dart
+++ b/openidconnect/lib/src/openidconnect_client.dart
@@ -157,10 +157,7 @@ class OpenIdConnectClient {
 
       return _identity!;
     } on Exception catch (e) {
-      if (this._identity != null) {
-        await OpenIdIdentity.clear();
-        this._identity = null;
-      }
+      clearIdentity();
       _raiseEvent(AuthEvent(AuthEventTypes.Error, message: e.toString()));
       throw AuthenticationException(e.toString());
     }
@@ -190,13 +187,8 @@ class OpenIdConnectClient {
       _raiseEvent(AuthEvent(AuthEventTypes.Success));
       return _identity!;
     } on Exception catch (e) {
-      if (this._identity != null) {
-        await OpenIdIdentity.clear();
-        this._identity = null;
-      }
-
+      clearIdentity();
       _raiseEvent(AuthEvent(AuthEventTypes.Error, message: e.toString()));
-
       throw AuthenticationException(e.toString());
     }
   }
@@ -252,13 +244,8 @@ class OpenIdConnectClient {
 
       return _identity!;
     } on Exception catch (e) {
-      if (this._identity != null) {
-        await OpenIdIdentity.clear();
-        this._identity = null;
-      }
-
+      clearIdentity();
       _raiseEvent(AuthEvent(AuthEventTypes.Error, message: e.toString()));
-
       throw AuthenticationException(e.toString());
     }
   }
@@ -368,15 +355,18 @@ class OpenIdConnectClient {
 
       return true;
     } on Exception catch (e) {
-      if (this._identity != null) {
-        await OpenIdIdentity.clear();
-        this._identity = null;
-
-        _raiseEvent(AuthEvent(AuthEventTypes.Error, message: e.toString()));
-      }
+      clearIdentity();
+      _raiseEvent(AuthEvent(AuthEventTypes.Error, message: e.toString()));
       return false;
     } finally {
       _refreshing = false;
+    }
+  }
+
+  Future<void> clearIdentity() async {
+    if (this._identity != null) {
+      await OpenIdIdentity.clear();
+      this._identity = null;
     }
   }
 


### PR DESCRIPTION
Hi,
First of all, thanks for this awesome package that greatly helps dealing with OpenID Connect and saved me a big amount of work !!!

I have an issue with the package that fails loging the user out with Keycloak ID provider.
Thus, I added propose you this PR to fix this :
* Add capabilities to logout a keycloak user
* Also add the capabilities to revoke a keycloak token

> All these changes are backward compatible.

(By the way, I wonder if there is a bug in your logout code : you use `get` request instead of a `post` request + you should probably clear user's identity)

Thanks again for sharing this code.
Best regards,
Renaud