### PR TITLE
nullpointer fix

### DIFF
--- a/openidconnect/lib/src/config/openidconfiguration.dart
+++ b/openidconnect/lib/src/config/openidconfiguration.dart
@@ -12,7 +12,7 @@ class OpenIdConfiguration {
   final String? mfaChallengeEndpoint;
 
   final List<String> scopesSupported;
-  final List<String> claimsSupported;
+  final List<String>? claimsSupported;
   final List<String>? grantTypesSupported;
   final List<String> responseTypesSupported;
   final List<String> responseModesSupported;
@@ -39,7 +39,7 @@ class OpenIdConfiguration {
     this.registrationEndpoint,
     this.mfaChallengeEndpoint,
     required this.scopesSupported,
-    required this.claimsSupported,
+    this.claimsSupported,
     this.grantTypesSupported,
     required this.responseTypesSupported,
     required this.responseModesSupported,
@@ -70,8 +70,9 @@ class OpenIdConfiguration {
             json["device_authorization_endpoint"]?.toString(),
         scopesSupported:
             List<String>.from(json["scopes_supported"] as List<dynamic>),
-        claimsSupported:
-            List<String>.from(json["claims_supported"] as List<dynamic>),
+        claimsSupported: json["claims_supported"] == null
+            ? null
+            : List<String>.from(json["claims_supported"] as List<dynamic>),
         grantTypesSupported: json["grant_types_supported"] == null
             ? null
             : List<String>.from(json["grant_types_supported"] as List<dynamic>),

--- a/openidconnect/lib/src/config/openidconfiguration.dart
+++ b/openidconnect/lib/src/config/openidconfiguration.dart
@@ -11,7 +11,7 @@ class OpenIdConfiguration {
   final String? registrationEndpoint;
   final String? mfaChallengeEndpoint;
 
-  final List<String> scopesSupported;
+  final List<String>? scopesSupported;
   final List<String>? claimsSupported;
   final List<String>? grantTypesSupported;
   final List<String> responseTypesSupported;
@@ -38,7 +38,7 @@ class OpenIdConfiguration {
     this.revocationEndpoint,
     this.registrationEndpoint,
     this.mfaChallengeEndpoint,
-    required this.scopesSupported,
+    this.scopesSupported,
     this.claimsSupported,
     this.grantTypesSupported,
     required this.responseTypesSupported,
@@ -68,8 +68,9 @@ class OpenIdConfiguration {
         mfaChallengeEndpoint: json["mfa_challenge_endpoint"]?.toString(),
         deviceAuthorizationEndpoint:
             json["device_authorization_endpoint"]?.toString(),
-        scopesSupported:
-            List<String>.from(json["scopes_supported"] as List<dynamic>),
+        scopesSupported: json["scopes_supported"] == null
+            ? null
+            : List<String>.from(json["scopes_supported"] as List<dynamic>),
         claimsSupported: json["claims_supported"] == null
             ? null
             : List<String>.from(json["claims_supported"] as List<dynamic>),


### PR DESCRIPTION
Not all Open Id Connect providers follow the standard up to 100%. When calling the discovery endpoint, our provider does not provide information about the "claims_supported".
This leads to a null pointer exception. 
This pull request would fix the error by making the claims_supported optional. 