### PR TITLE
🐛 fix: tokens not being saved when doing interactive login with redirects

### DIFF
--- a/openidconnect/lib/src/openidconnect_client.dart
+++ b/openidconnect/lib/src/openidconnect_client.dart
@@ -77,8 +77,10 @@ class OpenIdConnectClient {
         autoRefresh: autoRefresh,
       );
 
-      if (response != null)
+      if (response != null) {
         _identity = OpenIdIdentity.fromAuthorizationResponse(response);
+        await this._identity?.save();
+      }
     }
 
     if (_identity == null) _identity = await OpenIdIdentity.load();


### PR DESCRIPTION
I noticed when you do interactive logins with redirects that the tokens were not being saved. If the app reloads after the initial load then it will lose valid tokens and force the user through the login process again.